### PR TITLE
Adding progress bars, on the fly plotting/saving and density matrix Observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ The elementary tensor operations are implemented in all cases using the [TensorO
 
 # Installation
 
-The package may be installed by typing the following into a Julia REPL
+The package may be installed by typing `]` in a Julia REPL to enter the package manager, and then run the command
 
 ```julia
-] add https://github.com/shareloqs/MPSDynamics.git
+pkg> add MPSDynamics
 ```
 
 # Usage

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,10 +8,9 @@ However the methods implemented can equally be applied to other areas of physics
 
 ## Installation
 
-The package may be installed by typing the following into a Julia REPL
-
+The package may be installed by typing `]` in a Julia REPL to enter the package manager, and then run the command
 ```julia
-    ] add https://github.com/shareloqs/MPSDynamics.git
+    pkg> add MPSDynamics
 ```
 
 ## Table of Contents

--- a/src/MPSDynamics.jl
+++ b/src/MPSDynamics.jl
@@ -173,7 +173,7 @@ export MPOtoVector
 
 export rhoreduced_2sites, rhoreduced_1site, protontransfermpo
 
-export chaincoeffs_finiteT, chaincoeffs_fermionic, fermionicspectraldensity_finiteT
+export chaincoeffs_finiteT, chaincoeffs_fermionic, fermionicspectraldensity_finiteT, chaincoeffs_finiteT_discrete
 
 end
 

--- a/src/finitetemperature.jl
+++ b/src/finitetemperature.jl
@@ -228,7 +228,6 @@ function chaincoeffs_finiteT_discrete(β, ωdiscrete, Jωdiscrete; procedure=:La
     ω = ωdiscrete
     Jω = Jωdiscrete
     length(ω)== length(Jω) || throw(ErrorException("J(ω) has $(length(Jω)) values while there is $(length(ω)) frequecencies"))
-    N=length(ω) #Number of bath modes
     if β != Inf
        ω_pos = ω
        Jω_pos = Jω .* (coth.((β/2).*ω_pos[:]) .+ 1) ./2
@@ -239,6 +238,8 @@ function chaincoeffs_finiteT_discrete(β, ωdiscrete, Jωdiscrete; procedure=:La
        ω = vcat(ω_neg,ω_pos)
        Jω =  vcat(Jω_neg,Jω_pos)
     end
+
+    N=length(ω) #Number of bath modes
     mp=length(ω) # the number of points in the discrete part of the measure
 
     DM =Array{Float64}(undef,mp,2)


### PR DESCRIPTION
This adds:

- Progress bars: implemented in a new src/ file called utilities.jl as a class on which one can iterate and which returns the time step so that we don't have to modify the run_... code too much. For 1TDVP this adds an ETA and for 2TDVP and DTDVP displays the maximum link size. To disable it them one has to add the parameter progressbar=false in `runsim`.

- "On the fly": also implemented mainly in the utilities.jl file (and a little in each run_...). Used to display results during simulations or to save temporary data. Simply use the `onthefly` function, which returns a dictionary to be passed in kwarg `onthefly=` to the `runsim` function. This dictionary contains in particular the names of the observables to be saved/plotted, the plot in question, the function used to process the observable and make it possible to graph it, a possible point of comparison on the plot and the number of steps to wait between two saves/graphs. All this is then used by the `ontheflysave` and `ontheflyplot` functions in the bodies of the run_... functions.

- Documentation: everything added above is detailled under the "Advanced" subsection of Methods

- `RhoReduced` which is a new `Observable` that allows to measure several density matrices reduced to 1 or 2 sites.